### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fmitchtabian%2FSQLite-for-Beginners-2019&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
+
 <a href='https://codingwithmitch.com/courses/sqlite-room-persistence-android/' target='_blank'><img class='header-img' src='https://codingwithmitch.s3.amazonaws.com/static/sqlite-room-persistence-android/images/SQlite_for_Beginners_2019.png' /></a>
 
 <h1><a href='https://codingwithmitch.com/courses/sqlite-room-persistence-android/' target='_blank'>Android SQLite for Beginners 2019</a></h1>


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1665)](https://user-images.githubusercontent.com/47092464/98453568-98a92e00-2195-11eb-93d3-c2c81232840e.png)
